### PR TITLE
Generic dog collar remote control

### DIFF
--- a/inc/RF_Config.h
+++ b/inc/RF_Config.h
@@ -31,4 +31,4 @@
 #define EFM8BB1_SUPPORT_DIO_PROTOCOL			1		// DIO Chacon RF 433Mhz, Issue #95
 #define EFM8BB1_SUPPORT_1BYONE_PROTOCOL			1		// 1ByOne Doorbell, PR #97
 #define EFM8BB1_SUPPORT_Prologue_PROTOCOL		1		// Prologue Sensor, Issue #96
-#define EFM8BB1_SUPPORT_DOG_COLLAR_PROTOCOL     1       // Generic dog training collar - board label T-187-n (TX)-1
+#define EFM8BB1_SUPPORT_DOG_COLLAR_PROTOCOL		1		// Generic dog training collar - board label T-187-n (TX)-1

--- a/inc/RF_Config.h
+++ b/inc/RF_Config.h
@@ -31,3 +31,4 @@
 #define EFM8BB1_SUPPORT_DIO_PROTOCOL			1		// DIO Chacon RF 433Mhz, Issue #95
 #define EFM8BB1_SUPPORT_1BYONE_PROTOCOL			1		// 1ByOne Doorbell, PR #97
 #define EFM8BB1_SUPPORT_Prologue_PROTOCOL		1		// Prologue Sensor, Issue #96
+#define EFM8BB1_SUPPORT_DOG_COLLAR_PROTOCOL     1       // Generic dog training collar - board label T-187-n (TX)-1

--- a/inc/RF_Protocols.h
+++ b/inc/RF_Protocols.h
@@ -272,6 +272,18 @@ SI_SEGMENT_VARIABLE(PROTOCOL_BIT1(Prologue)[], static uint8_t, SI_SEG_CODE) = { 
 SI_SEGMENT_VARIABLE(PROTOCOL_END(Prologue)[], static uint8_t, SI_SEG_CODE) = { HIGH(0), LOW(1) };
 #endif
 
+/*
+ * T-187-N (TX)-1 Generic Dog Training Collar Remote Control
+ */
+#if EFM8BB1_SUPPORT_DOG_COLLAR_PROTOCOL == 1
+#define DogCollar
+SI_SEGMENT_VARIABLE(PROTOCOL_BUCKETS(DogCollar)[], static uint16_t, SI_SEG_CODE) = { 1560, 720, 210 };
+SI_SEGMENT_VARIABLE(PROTOCOL_START(DogCollar)[], static uint8_t, SI_SEG_CODE) = { HIGH(0), LOW(1) };
+SI_SEGMENT_VARIABLE(PROTOCOL_BIT0(DogCollar)[], static uint8_t, SI_SEG_CODE) = { HIGH(2), LOW(1) };
+SI_SEGMENT_VARIABLE(PROTOCOL_BIT1(DogCollar)[], static uint8_t, SI_SEG_CODE) = { HIGH(1), LOW(2) };
+SI_SEGMENT_VARIABLE(PROTOCOL_END(DogCollar)[], static uint8_t, SI_SEG_CODE) = { HIGH(2), LOW(1) };
+#endif
+
 SI_SEGMENT_VARIABLE(PROTOCOL_DATA[], static struct BUCKET_PROTOCOL_DATA, SI_SEG_CODE) =
 {
 #if EFM8BB1_SUPPORT_PT226X_PROTOCOL == 1
@@ -493,6 +505,19 @@ SI_SEGMENT_VARIABLE(PROTOCOL_DATA[], static struct BUCKET_PROTOCOL_DATA, SI_SEG_
 			{ &PROTOCOL_BIT1(Prologue), ARRAY_LENGTH(PROTOCOL_BIT1(Prologue)) },
 			{ &PROTOCOL_END(Prologue), ARRAY_LENGTH(PROTOCOL_END(Prologue)) },
 			36
+		},
+#endif
+#if EFM8BB1_SUPPORT_DOG_COLLAR_PROTOCOL == 1
+		/*
+		 * T-187-N (TX)-1 Generic Dog Training Collar Remote Control
+		 */
+		{
+			{ &PROTOCOL_BUCKETS(DogCollar), ARRAY_LENGTH(PROTOCOL_BUCKETS(DogCollar)) },
+			{ &PROTOCOL_START(DogCollar), ARRAY_LENGTH(PROTOCOL_START(DogCollar)) },
+			{ &PROTOCOL_BIT0(DogCollar), ARRAY_LENGTH(PROTOCOL_BIT0(DogCollar)) },
+			{ &PROTOCOL_BIT1(DogCollar), ARRAY_LENGTH(PROTOCOL_BIT1(DogCollar)) },
+			{ &PROTOCOL_END(DogCollar), ARRAY_LENGTH(PROTOCOL_END(DogCollar)) },
+			40
 		},
 #endif
 };


### PR DESCRIPTION
Added protocol definition for generic dog training collars (see https://gist.github.com/tkuester/67f2d8f5c03aee22c6d7 for more detail on the data protocol).  I cannot seem to get Simplicity Studio and Keil compiler working so this isn't tested, however the bucket definitions have been tested using rfraw commands.