### PR TITLE
Support new Tasmota MQTT format to detect RfRaw message

### DIFF
--- a/BitBucketConverter.py
+++ b/BitBucketConverter.py
@@ -284,7 +284,7 @@ def parse_file(fn):
     commands={}
     with open(fn) as f:
         for line in f:
-            if '{"RfRaw":{"Data":"AA B1' in line:
+            if '"RfRaw":{"Data":"AA B1' in line:
                 print("###### Processing line {0} ######".format(line))
                 res=main(filterInputStr(line)
                          , options.repeat)


### PR DESCRIPTION
It seems that in recent version of Tasmota, the MQTT message format has been changed to add time data.

Old example:
```
18:30:23 MQT: /sonoff/bridge/RESULT = {"RfRaw":{"Data":"AA B1 04 0224 03FB 0BF4 1CAC 01101001100101011010100110010101101010010110011023 55"}}
```

Mine, currently (Tasmota 9.2.0):
```
21:20:06 MQT: tele/rfbridge/RESULT = {"Time":"2021-01-12T21:20:06","RfRaw":{"Data":"AA B1 04 0140 00E6 051E 0514 381828 55"}}
```

I don't know since when this change happened, or could it be configured. But we can see it everywhere, e.g. in March 2020 https://github.com/Portisch/RF-Bridge-EFM8BB1/issues/155