### PR TITLE
Small changes on BitBucketConverter.py to compile with python 3.7.3

### DIFF
--- a/BitBucketConverter.py
+++ b/BitBucketConverter.py
@@ -61,7 +61,7 @@ def filterInputStr(auxStr):
 
 def getInputStr():
     #auxStr = '18:30:23 MQT: /sonoff/bridge/RESULT = {"RfRaw":{"Data":"AA B1 04 0224 03FB 0BF4 1CAC 01101001100101011010100110010101101010010110011023 55"}}'
-    auxStr = raw_input("Enter B1 line: ")
+    auxStr = input("Enter B1 line: ")
     auxStr = filterInputStr(auxStr)
     return auxStr
 
@@ -161,7 +161,7 @@ def findSyncPattern(szData):
 
     if ((len(szData) % 2) != 0):
         print("Missing bucket in data...")
-        sys.exit()
+        exit()
 
     # try first if the second sync bucket is on the end of the data
     bucketAtEnd = True


### PR DESCRIPTION
I tried to run the converter python script, as the online converter is down currently.
Python version 3.7.3, OS Version: Raspbian GNU/Linux 10 (buster)

There were a few issures I run into:

1. dependency pycurl was missing. In order to install it i needed to install some system libraries:
```
 sudo apt install libcurl4-openssl-dev 
 sudo apt install libssl-dev
```
after that I was able to install pycurl via ``pip3 install pycurl``

2. script still did not compile because of a few typos (propably mixups between python 3 and python 2). 
I did some minor changes which I propose in this PR 

After the changes I was able to run the script successfully with python 3